### PR TITLE
  Remove MomentJS 

### DIFF
--- a/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/main/resources/runtime/typescript/irt/formatter.ts
+++ b/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/main/resources/runtime/typescript/irt/formatter.ts
@@ -1,78 +1,63 @@
+import dayjs from "dayjs";
+import customParseFormat from "dayjs/plugin/customParseFormat";
+import utc from "dayjs/plugin/utc";
 
-import * as moment from 'moment';
+dayjs.extend(customParseFormat);
+dayjs.extend(utc);
 
 export class Formatter {
-    public static readonly DATETIME_FORMATS = [
-        'YYYY-MM-DDTHH:mm:ssZ',
-        'YYYY-MM-DDTHH:mm:ss.SZ',
-        'YYYY-MM-DDTHH:mm:ss.SSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSSSZ',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSSSSZ',
-        'YYYY-MM-DDTHH:mm:ss',
-        'YYYY-MM-DDTHH:mm:ss.S',
-        'YYYY-MM-DDTHH:mm:ss.SS',
-        'YYYY-MM-DDTHH:mm:ss.SSS',
-        'YYYY-MM-DDTHH:mm:ss.SSSS',
-        'YYYY-MM-DDTHH:mm:ss.SSSSS',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSS',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSS',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSSS',
-        'YYYY-MM-DDTHH:mm:ss.SSSSSSSSS',
-    ];
+  public static readTime(value: string): Date {
+    return dayjs(value, "HH:mm:ss.SSS").toDate();
+  }
 
-    public static readTime(value: string): Date {
-        return moment(value, 'HH:mm:ss.SSS').toDate();
+  public static writeTime(value: Date): string {
+    return dayjs(value).format("HH:mm:ss.SSS");
+  }
+
+  public static readDate(value: string): Date {
+    return dayjs(value, "YYYY-MM-DD").toDate();
+  }
+
+  public static writeDate(value: Date): string {
+    return dayjs(value).format("YYYY-MM-DD");
+  }
+
+  public static readDateTime(value: string, utcMode: boolean = false): Date {
+    const regionIndex = value.indexOf("[");
+    if (regionIndex >= 0) {
+      // For the time being, we just ignore [Europe/Dublin] kind of regions
+      value = value.substring(0, regionIndex);
     }
 
-    public static writeTime(value: Date): string {
-        return moment(value).format('HH:mm:ss.SSS');
+    const dt = dayjs(value);
+    if (!dt.isValid()) {
+      throw new Error(`Invalid date format for value ${value}`);
     }
 
-    public static readDate(value: string): Date {
-        return moment(value, 'YYYY-MM-DD').toDate();
-    }
+    return utcMode ? dt.utc().toDate() : dt.toDate();
+  }
 
-    public static writeDate(value: Date): string {
-        return moment(value).format('YYYY-MM-DD');
-    }
+  public static readZoneDateTime(value: string): Date {
+    return Formatter.readDateTime(value);
+  }
 
-    public static readDateTime(value: string, utc: boolean = false): Date {
-        const regionIndex = value.indexOf('[');
-        if (regionIndex >= 0) {
-            // For the time being, we just ignore [Europe/Dublin] kind of regions
-            value = value.substring(0, regionIndex);
-        }
+  public static writeZoneDateTime(value: Date): string {
+    return dayjs(value).format("YYYY-MM-DDTHH:mm:ss.SSSZ");
+  }
 
-        const res = moment(value, Formatter.DATETIME_FORMATS);
-        return utc ? res.utc().toDate() : res.toDate();
-    }
+  public static readLocalDateTime(value: string): Date {
+    return Formatter.readDateTime(value);
+  }
 
-    public static readZoneDateTime(value: string): Date {
-        return Formatter.readDateTime(value);
-    }
+  public static writeLocalDateTime(value: Date): string {
+    return dayjs(value).format("YYYY-MM-DDTHH:mm:ss.SSS");
+  }
 
-    public static writeZoneDateTime(value: Date): string {
-        return moment(value).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-    }
+  public static readUTCDateTime(value: string): Date {
+    return Formatter.readDateTime(value, true);
+  }
 
-    public static readLocalDateTime(value: string): Date {
-        return Formatter.readDateTime(value);
-    }
-
-    public static writeLocalDateTime(value: Date): string {
-        return moment(value).format('YYYY-MM-DDTHH:mm:ss.SSS');
-    }
-
-    public static readUTCDateTime(value: string): Date {
-        return Formatter.readDateTime(value, true);
-    }
-
-    public static writeUTCDateTime(value: Date): string {
-        return moment(value).utc().format('YYYY-MM-DDTHH:mm:ss.SSSZ');
-    }
+  public static writeUTCDateTime(value: Date): string {
+    return dayjs(value).utc().format("YYYY-MM-DDTHH:mm:ss.SSS[Z]");
+  }
 }

--- a/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/main/resources/runtime/typescript/irt/test/formatter.test.ts
+++ b/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/main/resources/runtime/typescript/irt/test/formatter.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect } from "vitest";
+import { Formatter } from "../formatter";
+
+describe("Formatter", () => {
+  describe("Time mapping", () => {
+    it("should read and write time correctly", () => {
+      const expectedTime = "12:34:56.789";
+      const date = Formatter.readTime(expectedTime);
+      expect(date).toBeInstanceOf(Date);
+
+      const writeResult = Formatter.writeTime(date);
+      expect(writeResult).toBe(expectedTime);
+    });
+  });
+
+  describe("Date mapping", () => {
+    it("should read and write date correctly", () => {
+      const expectedDate = "2026-04-01";
+      const date = Formatter.readDate(expectedDate);
+      expect(date).toBeInstanceOf(Date);
+
+      const writeResult = Formatter.writeDate(date);
+      expect(writeResult).toBe(expectedDate);
+    });
+  });
+
+  describe("DateTime mapping", () => {
+    it("should strip region context like [Europe/Dublin] during parsing", () => {
+      const input = "2026-04-01T11:37:27.123Z[Europe/Dublin]";
+      const date = Formatter.readDateTime(input);
+      expect(date).toBeInstanceOf(Date);
+
+      const expectedDate = Formatter.readDateTime("2026-04-01T11:37:27.123Z");
+      expect(date.getTime()).toBe(expectedDate.getTime());
+    });
+
+    it("should properly fall back to standard formatting array", () => {
+      const input = "2026-04-01T11:37:27.123Z";
+      const date = Formatter.readDateTime(input);
+      expect(date).toBeInstanceOf(Date);
+    });
+
+    it("should correctly parse with or without UTC mode", () => {
+      const input = "2026-04-01T11:37:27.123Z";
+      const dateLocal = Formatter.readDateTime(input, false);
+      const dateUtc = Formatter.readDateTime(input, true);
+
+      expect(dateLocal).toBeInstanceOf(Date);
+      expect(dateUtc).toBeInstanceOf(Date);
+      expect(dateLocal.getTime()).toBe(dateUtc.getTime());
+    });
+  });
+
+  describe("ZoneDateTime mapping", () => {
+    it("should read and write ZoneDateTime correctly", () => {
+      const input = "2026-04-01T11:37:27.123+03:00";
+      const date = Formatter.readZoneDateTime(input);
+      expect(date).toBeInstanceOf(Date);
+
+      const written = Formatter.writeZoneDateTime(date);
+      expect(written).toMatch(
+        /\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}[+-Z]/,
+      );
+    });
+  });
+
+  describe("LocalDateTime mapping", () => {
+    it("should read and write LocalDateTime correctly", () => {
+      const localStr = "2026-04-01T11:37:27.123";
+      const date = Formatter.readLocalDateTime(localStr);
+      expect(date).toBeInstanceOf(Date);
+
+      const writeResult = Formatter.writeLocalDateTime(date);
+      expect(writeResult).toBe(localStr);
+    });
+  });
+
+  describe("UTCDateTime mapping", () => {
+    it("should read and write UTCDateTime correctly", () => {
+      const utcStr = "2026-04-01T11:37:27.123Z";
+      const date = Formatter.readUTCDateTime(utcStr);
+      expect(date).toBeInstanceOf(Date);
+
+      const writeResult = Formatter.writeUTCDateTime(date);
+      expect(writeResult).toBe(utcStr);
+    });
+  });
+});

--- a/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/npmjs/package.json
+++ b/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/npmjs/package.json
@@ -10,10 +10,15 @@
     "url": "https://github.com/7mind/idealingua-v1.git"
   },
   "dependencies": {
-    "moment": "^2.29.1",
-    "websocket": "^1.0.32",
     "@types/node": "^22.7.6",
-    "@types/websocket": "^1.0.1"
+    "@types/websocket": "^1.0.1",
+    "dayjs": "^1.11.10",
+    "websocket": "^1.0.32"
   },
-  "peerDependencies": {}
+  "devDependencies": {
+    "vitest": "^1.5.0"
+  },
+  "scripts": {
+    "test": "vitest run --dir ../main/resources/runtime/typescript/irt/test"
+  }
 }

--- a/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/npmjs/tsconfig.json
+++ b/idealingua-v1/idealingua-v1-runtime-rpc-typescript/src/npmjs/tsconfig.json
@@ -29,7 +29,8 @@
     "ignoreDeprecations": "5.0",
     "experimentalDecorators" : true,
     "removeComments" : true,
-    "preserveConstEnums" : true
+    "preserveConstEnums" : true,
+    "esModuleInterop" : true
   },
   "compileOnSave" : false
 }

--- a/idealingua-v1/idealingua-v1-runtime-rpc-typescript/tsconfig.json
+++ b/idealingua-v1/idealingua-v1-runtime-rpc-typescript/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./src/npmjs/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "*": [
+        "src/main/resources/runtime/typescript/irt/*",
+        "src/npmjs/node_modules/*"
+      ]
+    },
+    "typeRoots": [
+      "src/npmjs/node_modules/@types"
+    ]
+  },
+  "include": [
+    "src/main/resources/runtime/typescript/**/*.ts"
+  ]
+}


### PR DESCRIPTION
# What's new 
- Replaced `moment` with `day.js`

### Why day.js? 
-  The library is only ~2KB, compared to alternatives like Luxon which is ~30KB.
-  It has almost the exact same API and syntax as `moment.js`, making the transition smooth and safe.

### Why not Temporal? 
- Node.js does not natively support Temporal yet. 
- The current workaround is to use polyfills, which would add 100KB+ to our bundle. This goes against our goal of optimizing size and is not a good solution for us right now.