### PR TITLE
Fix cross-domain AnyVal regression in Scala output

### DIFF
--- a/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/ir/Domain.scala
+++ b/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/ir/Domain.scala
@@ -50,6 +50,15 @@ import izumi.idealingua.model.il.ast.typed.DomainMetadata
   *                            local structs (e.g. cast-similar peer
   *                            detection, anyval candidate scan) do not
   *                            accidentally surface foreign entries.
+  * @param crossDomainUserTypes
+  *                            Every foreign `TypeDef` reachable through any
+  *                            foreign domain this domain transitively touches
+  *                            (super-driven + field-driven harvest). Used by
+  *                            Scala-renderer AnyVal predicates so single-scalar
+  *                            DTOs carrying foreign identifiers extend `AnyVal`
+  *                            with legacy parity. Look up via `findUserType` /
+  *                            `findFlatStruct` accessors rather than reading
+  *                            the cross-domain maps directly.
   * @param parents             Maps each structural `TypeId` to the set of
   *                            `InterfaceId`s it directly or transitively
   *                            extends.
@@ -75,6 +84,7 @@ final case class Domain(
   ephemeralOwner: Map[TypeId, TypeId],
   flattenedStructs: Map[StructureId, FlatStruct],
   crossDomainFlattenedStructs: Map[StructureId, FlatStruct] = Map.empty,
+  crossDomainUserTypes: Map[TypeId, TypeDef] = Map.empty,
   parents: Map[TypeId, Set[InterfaceId]],
   implementingDtos: Map[InterfaceId, Set[DTOId]],
   loops: Set[Cycle[TypeId]],
@@ -84,4 +94,15 @@ final case class Domain(
   consts: List[Const],
   aliases: Map[AliasId, TypeId],
   userTypes: Map[TypeId, TypeDef],
-)
+) {
+
+  /** Look up a user type that may be local or cross-domain; consults
+    * `userTypes` first, then `crossDomainUserTypes` as fallback. */
+  def findUserType(t: TypeId): Option[TypeDef] =
+    userTypes.get(t).orElse(crossDomainUserTypes.get(t))
+
+  /** Look up a flattened struct that may be local or cross-domain; consults
+    * `flattenedStructs` first, then `crossDomainFlattenedStructs` as fallback. */
+  def findFlatStruct(s: StructureId): Option[FlatStruct] =
+    flattenedStructs.get(s).orElse(crossDomainFlattenedStructs.get(s))
+}

--- a/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/ir/ResolvedDomain.scala
+++ b/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/ir/ResolvedDomain.scala
@@ -61,6 +61,12 @@ import scodec.bits.ByteVector
   *                            populates.
   * @param typedConsts         Type-checked constants in declaration order.
   *                            Phase 8 populates.
+  * @param crossDomainUserTypes
+  *                            Every foreign `TypeDef` reachable through any
+  *                            foreign domain this domain transitively touches
+  *                            (super-driven + field-driven harvest). Prefer
+  *                            `findUserType` / `findFlatStruct` accessors on
+  *                            `Domain` rather than reading this map directly.
   * @param diagnostics         Accumulated diagnostics from Phases 1-10.
   */
 final case class ResolvedDomain(
@@ -74,6 +80,7 @@ final case class ResolvedDomain(
   loops: Set[Cycle[TypeId]] = Set.empty,
   flattenedStructs: Map[StructureId, FlatStruct] = Map.empty,
   crossDomainFlattenedStructs: Map[StructureId, FlatStruct] = Map.empty,
+  crossDomainUserTypes: Map[TypeId, TypeDef] = Map.empty,
   parents: Map[TypeId, Set[InterfaceId]] = Map.empty,
   implementingDtos: Map[InterfaceId, Set[DTOId]] = Map.empty,
   ephemeralsOf: Map[TypeId, Set[TypeId]] = Map.empty,

--- a/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/phase/Assembler.scala
+++ b/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/phase/Assembler.scala
@@ -22,6 +22,7 @@ object Assembler {
     ephemeralOwner    = rd.ephemeralOwner,
     flattenedStructs  = rd.flattenedStructs,
     crossDomainFlattenedStructs = rd.crossDomainFlattenedStructs,
+    crossDomainUserTypes        = rd.crossDomainUserTypes,
     parents           = rd.parents,
     implementingDtos  = rd.implementingDtos,
     loops             = rd.loops,

--- a/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/phase/StructuralFlattener.scala
+++ b/idealingua-v1/idealingua-v1-model/src/main/scala/izumi/idealingua/typer/phase/StructuralFlattener.scala
@@ -169,8 +169,15 @@ object StructuralFlattener {
     // supertypes so the BFS walker eventually reaches every transitive
     // ancestor. Foreign diagnostics are dropped — the foreign domain owns
     // its own pipeline run and surfaces its own diagnostics there.
+    //
+    // Full TypeDef for every foreign user type reachable through field references
+    // (not just supers). Populated below alongside the super-driven harvest;
+    // consumed by renderer-side AnyVal predicates and other consumers that need
+    // to classify cross-domain types (e.g. `DomainAnyvalExtension.canBeAnyValField`).
+    val foreignUserTypesBuf = mutable.LinkedHashMap.empty[TypeId, TypeDef]
     family.foreach { fam =>
-      val foreignResolved = mutable.HashMap.empty[DomainId, Option[ResolvedDomain]]
+      val foreignResolved  = mutable.HashMap.empty[DomainId, Option[ResolvedDomain]]
+      val indexedDomains   = mutable.HashSet.empty[DomainId]
 
       def resolveForeign(d: DomainId): Option[ResolvedDomain] =
         foreignResolved.getOrElseUpdate(
@@ -184,9 +191,41 @@ object StructuralFlattener {
           },
         )
 
+      // Once a foreign domain is resolved, store the full TypeDef for every
+      // foreign user type. Consumers query this map to classify cross-domain
+      // types that appear in local field positions (e.g.
+      // `data D { val: foreign.X#ItemID }`). Widened from Identifier-only to
+      // all TypeDef categories so enums, ADTs, DTOs, aliases, etc. are also
+      // available for free.
+      // D08: memoised via `indexedDomains` — each domain is walked at most once.
+      def indexForeignUserTypes(d: DomainId): Unit = {
+        if (!indexedDomains.add(d)) return
+        resolveForeign(d).foreach { resolved =>
+          resolved.userTypes.foreach {
+            case (id, td) if id.path.domain != rd.id => foreignUserTypesBuf.update(id, td)
+            case _ => ()
+          }
+        }
+      }
+
+      // Helper shared by DTO and Interface branches of harvest: for each field
+      // of a freshly-harvested foreign struct, index the field's domain and
+      // recursively harvest any foreign StructureId referenced — so third-domain
+      // (and deeper) types are reached transitively (D06).
+      def harvestFieldTypes(fields: List[Field]): Unit = fields.foreach { f =>
+        val tid = f.typeId
+        val d   = tid.path.domain
+        if (d != rd.id) indexForeignUserTypes(d)
+        tid match {
+          case sid: StructureId if sid.path.domain != rd.id => harvest(sid)
+          case _                                             => ()
+        }
+      }
+
       def harvest(id: StructureId): Unit = {
         if (views.contains(id)) return
         val resolved = resolveForeign(id.path.domain).getOrElse(return)
+        indexForeignUserTypes(id.path.domain)
         resolved.userTypes.get(id) match {
           case Some(dto: TypeDef.Dto) =>
             views.update(
@@ -202,6 +241,7 @@ object StructuralFlattener {
             directInterfaces.update(id, dto.struct.superclasses.interfaces)
             directConcepts.update(id, dto.struct.superclasses.concepts)
             (dto.struct.superclasses.interfaces ++ dto.struct.superclasses.concepts).foreach(harvest)
+            harvestFieldTypes(dto.struct.fields)
           case Some(ifc: TypeDef.Interface) =>
             views.update(
               id,
@@ -216,6 +256,7 @@ object StructuralFlattener {
             directInterfaces.update(id, ifc.struct.superclasses.interfaces)
             directConcepts.update(id, ifc.struct.superclasses.concepts)
             (ifc.struct.superclasses.interfaces ++ ifc.struct.superclasses.concepts).foreach(harvest)
+            harvestFieldTypes(ifc.struct.fields)
           case _ => ()
         }
       }
@@ -225,6 +266,43 @@ object StructuralFlattener {
       seedSupers.foreach { sup =>
         if (sup.path.domain != rd.id) harvest(sup)
       }
+
+      // Seed foreign user-type harvest and DTO/Interface struct harvest from
+      // first-hop field-type references. With the new transitive harvest in
+      // `harvest` itself (D06), this seed only needs to find the *first-hop*
+      // foreign references — `harvest` follows deeper hops automatically.
+      val foreignFieldDomains = mutable.LinkedHashSet.empty[DomainId]
+      // Collect foreign StructureId (DTOId / InterfaceId) references seen in
+      // field positions. `harvest(sid)` populates `crossDomainFlattenedStructs`
+      // for those structs, which `canBeAnyValField` consults when classifying
+      // a local DTO that carries a single foreign DTO/Interface field. The
+      // super-driven harvest only follows mixin parents, so a foreign struct
+      // referenced purely as a field type (not as a mixin) would otherwise
+      // remain absent from `crossDomainFlattenedStructs` and the predicate
+      // would return `false`, breaking AnyVal emission for those shapes.
+      val foreignFieldStructs = mutable.LinkedHashSet.empty[StructureId]
+      def collectDomain(tid: TypeId): Unit = {
+        val d = tid.path.domain
+        if (d != rd.id) {
+          val _ = foreignFieldDomains.add(d)
+          tid match {
+            case sid: StructureId => val _ = foreignFieldStructs.add(sid)
+            case _                => ()
+          }
+        }
+      }
+      views.values.foreach(_.fields.foreach(f => collectDomain(f.typeId)))
+      rd.userTypes.values.foreach {
+        case TypeDef.Identifier(_, fields, _) => fields.foreach(f => collectDomain(f.typeId))
+        case TypeDef.Alias(_, target, _)      => collectDomain(target)
+        case _                                => ()
+      }
+      foreignFieldDomains.foreach(indexForeignUserTypes)
+      // Second pass: harvest foreign DTO/Interface structs referenced in field
+      // positions so `crossDomainFlattenedStructs` is populated for them.
+      // `harvest` calls `indexForeignUserTypes` internally, so the full foreign
+      // user-type set for any newly-visited domain is indexed for free.
+      foreignFieldStructs.foreach(harvest)
     }
 
     /** Walk only `interfaces` edges; recurses transitively. Returns the
@@ -386,6 +464,7 @@ object StructuralFlattener {
       implementingDtos            = implementingDtos,
       flattenedStructs            = flatBuf.toMap,
       crossDomainFlattenedStructs = foreignFlatBuf.toMap,
+      crossDomainUserTypes        = foreignUserTypesBuf.toMap,
       diagnostics                 = rd.diagnostics ++ Diagnostics(diagBuf.toVector),
     )
   }

--- a/idealingua-v1/idealingua-v1-model/src/test/scala/izumi/idealingua/typer/phase/StructuralFlattenerSpec.scala
+++ b/idealingua-v1/idealingua-v1-model/src/test/scala/izumi/idealingua/typer/phase/StructuralFlattenerSpec.scala
@@ -1,9 +1,11 @@
 package izumi.idealingua.typer.phase
 
 import izumi.idealingua.model.common.TypeId._
-import izumi.idealingua.model.common.{IndefiniteId, TypePath}
+import izumi.idealingua.model.common.{DomainId, IndefiniteId, TypePath}
 import izumi.idealingua.model.il.ast.raw.defns._
-import izumi.idealingua.typer.ir.Diagnostic
+import izumi.idealingua.model.il.ast.raw.domains.{DomainMeshLoaded, ImportedId, SingleImport}
+import izumi.idealingua.model.loader.FSPath
+import izumi.idealingua.typer.ir.{Diagnostic, Diagnostics, FamilyIndex}
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers
 
@@ -226,6 +228,113 @@ final class StructuralFlattenerSpec extends AnyFunSpec with Matchers {
       dtoFlat.conflictsSoft.head.fields.head.field.typeId shouldBe covAId
 
       rd.diagnostics.issues.collect { case d: Diagnostic.FieldNameConflict => d } shouldBe empty
+    }
+
+    // ---- PR-01-D07: write-side harvest test ----
+    //
+    // Verifies that `StructuralFlattener.apply(local, family)` populates
+    // `crossDomainUserTypes` and `crossDomainFlattenedStructs` when the
+    // local domain references foreign types only through field positions
+    // (not as mixin supers).  This exercises the write-side of the harvest
+    // so a regression that leaves those maps empty is caught at the unit
+    // level rather than only through full-pipeline IDL fixtures.
+
+    it("populates crossDomainUserTypes and crossDomainFlattenedStructs from field-type references") {
+      // --- foreign domain: idltest.foreign_ids ---
+      //   identifier ItemID { f1: str; f2: str }
+      //   data MultiFieldDto { x: str; y: str }
+      val domForeign  = DomainId(Seq("idltest"), "foreign_ids")
+      val itemIdId    = IdentifierId(TypePath(domForeign, Seq.empty), "ItemID")
+      val foreignDtoId = DTOId(TypePath(domForeign, Seq.empty), "MultiFieldDto")
+
+      val foreignIdentDef = RawTypeDef.Identifier(
+        itemIdId,
+        List(
+          RawField(IndefiniteId(Seq.empty, "str"), Some("f1"), meta),
+          RawField(IndefiniteId(Seq.empty, "str"), Some("f2"), meta),
+        ),
+        meta,
+      )
+      val foreignDtoDef = RawTypeDef.DTO(
+        foreignDtoId,
+        RawStructure(Nil, Nil, Nil, List(
+          RawField(IndefiniteId(Seq.empty, "str"), Some("x"), meta),
+          RawField(IndefiniteId(Seq.empty, "str"), Some("y"), meta),
+        ), Nil),
+        meta,
+      )
+
+      val foreignDefn  = resolved(domForeign, List(foreignIdentDef, foreignDtoDef))
+      val foreignMesh = DomainMeshLoaded(
+        id               = domForeign,
+        origin           = FSPath.Name("foreign_ids.domain"),
+        directInclusions = Seq.empty,
+        originalImports  = Seq.empty,
+        meta             = meta,
+        types            = List(foreignIdentDef, foreignDtoDef),
+        services         = Seq.empty,
+        buzzers          = Seq.empty,
+        streams          = Seq.empty,
+        consts           = Seq.empty,
+        imports          = Seq.empty,
+        defn             = foreignDefn,
+      )
+
+      // --- local domain: idltest.a (= domA) ---
+      //   imports ItemID and MultiFieldDto from domForeign
+      //   data D    { val: ItemID      }
+      //   data D2   { val: MultiFieldDto }
+      val localImports = List(
+        SingleImport(domForeign, ImportedId("ItemID",       None)),
+        SingleImport(domForeign, ImportedId("MultiFieldDto", None)),
+      )
+      val dDef = RawTypeDef.DTO(
+        DTOId(TypePath(domA, Seq.empty), "D"),
+        RawStructure(Nil, Nil, Nil, List(RawField(IndefiniteId(Seq.empty, "ItemID"),       Some("val"), meta)), Nil),
+        meta,
+      )
+      val d2Def = RawTypeDef.DTO(
+        DTOId(TypePath(domA, Seq.empty), "D2"),
+        RawStructure(Nil, Nil, Nil, List(RawField(IndefiniteId(Seq.empty, "MultiFieldDto"), Some("val"), meta)), Nil),
+        meta,
+      )
+
+      val (localMesh, _) = fixture(
+        local      = List(dDef, d2Def),
+        imports    = localImports,
+        referenced = Map(domForeign -> foreignDefn),
+      )
+
+      // Build a FamilyIndex containing both domains so StructuralFlattener can
+      // resolve the foreign mesh when it follows field-type references.
+      val family = FamilyIndex(
+        domains     = Map(domA -> localMesh, domForeign -> foreignMesh),
+        importGraph = Map(domA -> Set(domForeign), domForeign -> Set.empty[DomainId]),
+        loadOrder   = List(domForeign, domA),
+        diagnostics = Diagnostics.empty,
+      )
+
+      // Run local domain through the typer pipeline up to (but not including)
+      // StructuralFlattener, then apply StructuralFlattener with the family.
+      val localRd0 = AliasDealiaser(KindChecker(NameResolver(ScopeBuilder(domA, localMesh, family), family)))
+      val localRd  = StructuralFlattener(CycleDetector(localRd0), family)
+
+      // Write-side assertions: the harvest must have populated the maps.
+      import izumi.idealingua.typer.ir.TypeDef
+      localRd.crossDomainUserTypes.get(itemIdId) match {
+        case Some(td: TypeDef.Identifier) => td.fields.size shouldBe 2
+        case other                        => fail(s"expected TypeDef.Identifier, got $other")
+      }
+
+      localRd.crossDomainFlattenedStructs should contain key foreignDtoId
+      localRd.crossDomainFlattenedStructs(foreignDtoId).fields.size shouldBe 2
+
+      // PR-02-D02: the widening to all TypeDef categories means the foreign DTO
+      // must also appear in crossDomainUserTypes as a TypeDef.Dto.
+      localRd.crossDomainUserTypes.get(foreignDtoId) match {
+        case Some(_: TypeDef.Dto) => // expected
+        case other                => fail(s"expected TypeDef.Dto for foreignDtoId, got $other")
+      }
     }
   }
 }

--- a/idealingua-v1/idealingua-v1-test-harness/src/test/scala/izumi/idealingua/harness/DomainAnyvalExtensionSpec.scala
+++ b/idealingua-v1/idealingua-v1-test-harness/src/test/scala/izumi/idealingua/harness/DomainAnyvalExtensionSpec.scala
@@ -1,6 +1,7 @@
 package izumi.idealingua.harness
 
-import izumi.idealingua.model.common.TypeId.{DTOId, IdentifierId, InterfaceId}
+import izumi.idealingua.model.common.TypeId.{AliasId, DTOId, IdentifierId, InterfaceId}
+import izumi.idealingua.model.common.StructureId
 import izumi.idealingua.model.common.{DomainId, Primitive, TypePath}
 import izumi.idealingua.model.il.ast.InputPosition
 import izumi.idealingua.model.il.ast.raw.defns.{RawNodeMeta, RawTopLevelDefn}
@@ -36,13 +37,21 @@ final class DomainAnyvalExtensionSpec extends AnyFunSuite {
   private def metaFor(d: DomainId) =
     DomainMetadata(FSPath(d.toPackage :+ s"${d.id}.domain"), Seq.empty, Seq.empty, emptyMeta)
 
-  private def ctxFor(extras: Map[izumi.idealingua.model.common.TypeId, NewTypeDef], flats: Map[izumi.idealingua.model.common.StructureId, FlatStruct]): DomainSTContext = {
+  private def ctxFor(
+    extras: Map[izumi.idealingua.model.common.TypeId, NewTypeDef],
+    flats: Map[StructureId, FlatStruct],
+    crossDomainUserTypes: Map[izumi.idealingua.model.common.TypeId, NewTypeDef] = Map.empty,
+    aliases: Map[AliasId, izumi.idealingua.model.common.TypeId] = Map.empty,
+    crossDomainFlattenedStructs: Map[StructureId, FlatStruct] = Map.empty,
+  ): DomainSTContext = {
     val dom = Domain(
       id = domainId, meta = metaFor(domainId), members = Map.empty, roots = Set.empty,
       ephemeralsOf = Map.empty, ephemeralOwner = Map.empty, flattenedStructs = flats,
+      crossDomainFlattenedStructs = crossDomainFlattenedStructs,
+      crossDomainUserTypes = crossDomainUserTypes,
       parents = Map.empty, implementingDtos = Map.empty, loops = Set.empty,
       fingerprints = Map.empty, domainFingerprint = Fingerprint(ByteVector.empty),
-      imports = Map.empty, consts = List.empty, aliases = Map.empty, userTypes = extras,
+      imports = Map.empty, consts = List.empty, aliases = aliases, userTypes = extras,
     )
     val parsed: DomainMeshResolved = new DomainMeshResolved {
       override def id: DomainId = domainId
@@ -107,5 +116,186 @@ final class DomainAnyvalExtensionSpec extends AnyFunSuite {
     )
     val ctx = ctxFor(Map(id -> td), flats)
     assert(DomainAnyvalExtension.withAnyForInterface(ctx, td).size == 1)
+  }
+
+  // Regression: DTO mixing in an empty interface and wrapping a single 2-field
+  // identifier field must extend AnyVal. The flat struct has one entry (the
+  // identifier field); the identifier itself has 2 fields, which makes it
+  // AnyVal-carrier-eligible. Legacy parity: `Test01DataAnyVal1` in
+  // idltest.anyvals + an identifier-typed scalar field.
+  test("DTO with empty mixin and single identifier field gets AnyVal init") {
+    val idId   = IdentifierId(tp, "ItemID")
+    val idDef  = NewTypeDef.Identifier(idId,
+      List(
+        IdField.PrimitiveField(Primitive.TUUID, "id", emptyMeta),
+        IdField.PrimitiveField(Primitive.TUUID, "app", emptyMeta),
+      ), emptyMeta)
+
+    val mixinId = InterfaceId(tp, "NodeVarBase")
+    val mixin   = NewTypeDef.Interface(mixinId, Struct(List.empty, List.empty, Super.empty), emptyMeta)
+
+    val dtoId = DTOId(tp, "NodeVarItem")
+    val field = Field(idId, "val", emptyMeta)
+    val dto   = NewTypeDef.Dto(dtoId, Struct(List(field), List.empty, Super(List(mixinId), List.empty, List.empty)), emptyMeta)
+
+    val flats = Map[izumi.idealingua.model.common.StructureId, FlatStruct](
+      dtoId   -> FlatStruct(dtoId, List(FlatField(field, dtoId, 0)), List.empty, List.empty),
+      mixinId -> FlatStruct(mixinId, List.empty, List.empty, List.empty),
+    )
+    val ctx = ctxFor(Map(idId -> idDef, mixinId -> mixin, dtoId -> dto), flats)
+    assert(DomainAnyvalExtension.withAnyvalForComposite(ctx, dto).size == 1)
+    assert(DomainAnyvalExtension.structCanBeAnyVal(ctx, dto))
+  }
+
+  // Regression: same shape, but the referenced identifier lives in a
+  // different domain. Legacy parity required `Typespace`-wide lookup for the
+  // field-count check; the new IR resolves the cross-domain identifier
+  // through `crossDomainUserTypes` populated by `StructuralFlattener`.
+  test("DTO with single foreign identifier field gets AnyVal init") {
+    val foreignDomain = DomainId(Seq("idltest"), "foreign_ids")
+    val foreignPath   = TypePath(foreignDomain, Seq.empty)
+    val foreignIdId   = IdentifierId(foreignPath, "ItemID")
+
+    val mixinId = InterfaceId(tp, "NodeVarBase")
+    val mixin   = NewTypeDef.Interface(mixinId, Struct(List.empty, List.empty, Super.empty), emptyMeta)
+
+    val dtoId = DTOId(tp, "NodeVarItem")
+    val field = Field(foreignIdId, "val", emptyMeta)
+    val dto   = NewTypeDef.Dto(dtoId, Struct(List(field), List.empty, Super(List(mixinId), List.empty, List.empty)), emptyMeta)
+
+    val flats = Map[izumi.idealingua.model.common.StructureId, FlatStruct](
+      dtoId   -> FlatStruct(dtoId, List(FlatField(field, dtoId, 0)), List.empty, List.empty),
+      mixinId -> FlatStruct(mixinId, List.empty, List.empty, List.empty),
+    )
+    val foreignIdDef = NewTypeDef.Identifier(foreignIdId,
+      List(
+        IdField.PrimitiveField(Primitive.TUUID, "id", emptyMeta),
+        IdField.PrimitiveField(Primitive.TUUID, "app", emptyMeta),
+      ), emptyMeta)
+    val ctx = ctxFor(
+      extras               = Map(mixinId -> mixin, dtoId -> dto),
+      flats                = flats,
+      crossDomainUserTypes = Map(foreignIdId -> foreignIdDef),
+    )
+    assert(DomainAnyvalExtension.withAnyvalForComposite(ctx, dto).size == 1)
+    assert(DomainAnyvalExtension.structCanBeAnyVal(ctx, dto))
+  }
+
+  // Regression: DTO whose single field resolves through a local alias that
+  // points at a foreign 2-field Identifier must still extend AnyVal.
+  // The alias-dealiasing arm in `canBeAnyValField` must recurse into the
+  // cross-domain user-types map.
+  test("DTO with alias-to-foreign-Identifier field gets AnyVal init") {
+    val foreignDomain = DomainId(Seq("idltest"), "foreign_ids")
+    val foreignPath   = TypePath(foreignDomain, Seq.empty)
+    val foreignIdId   = IdentifierId(foreignPath, "ItemID")
+
+    val aliasId = AliasId(tp, "A")
+    val dtoId   = DTOId(tp, "D")
+    val field   = Field(aliasId, "val", emptyMeta)
+    val dto     = NewTypeDef.Dto(dtoId, Struct(List(field), List.empty, Super.empty), emptyMeta)
+
+    val flats = Map[StructureId, FlatStruct](
+      dtoId -> FlatStruct(dtoId, List(FlatField(field, dtoId, 0)), List.empty, List.empty)
+    )
+    val foreignIdDef = NewTypeDef.Identifier(foreignIdId,
+      List(
+        IdField.PrimitiveField(Primitive.TUUID, "id", emptyMeta),
+        IdField.PrimitiveField(Primitive.TUUID, "app", emptyMeta),
+      ), emptyMeta)
+    val ctx = ctxFor(
+      extras               = Map(dtoId -> dto),
+      flats                = flats,
+      crossDomainUserTypes = Map(foreignIdId -> foreignIdDef),
+      aliases              = Map(aliasId -> foreignIdId),
+    )
+    assert(DomainAnyvalExtension.withAnyvalForComposite(ctx, dto) == List("AnyVal"))
+  }
+
+  // Regression (PR-01-D02): DTO whose single field is a foreign multi-field
+  // DTO must extend AnyVal. `canBeAnyValField` consults
+  // `crossDomainFlattenedStructs`; `StructuralFlattener` must populate that
+  // map via the field-driven harvest (not only via the super-driven harvest).
+  test("DTO with single foreign multi-field DTO field gets AnyVal init") {
+    val foreignDomain = DomainId(Seq("idltest"), "foreign_ids")
+    val foreignPath   = TypePath(foreignDomain, Seq.empty)
+    val foreignDtoId  = DTOId(foreignPath, "MultiFieldDto")
+
+    val fa = Field(Primitive.TString, "a", emptyMeta)
+    val fb = Field(Primitive.TInt32, "b", emptyMeta)
+
+    val dtoId = DTOId(tp, "D")
+    val field = Field(foreignDtoId, "val", emptyMeta)
+    val dto   = NewTypeDef.Dto(dtoId, Struct(List(field), List.empty, Super.empty), emptyMeta)
+
+    val flats = Map[StructureId, FlatStruct](
+      dtoId -> FlatStruct(dtoId, List(FlatField(field, dtoId, 0)), List.empty, List.empty)
+    )
+    val foreignFlat = FlatStruct(foreignDtoId, List(FlatField(fa, foreignDtoId, 0), FlatField(fb, foreignDtoId, 0)), List.empty, List.empty)
+    val ctx = ctxFor(
+      extras                     = Map(dtoId -> dto),
+      flats                      = flats,
+      crossDomainFlattenedStructs = Map(foreignDtoId -> foreignFlat),
+    )
+    assert(DomainAnyvalExtension.withAnyvalForComposite(ctx, dto) == List("AnyVal"))
+  }
+
+  // D01 follow-on: `canBeAnyValField` (now consolidated from three copies into
+  // one) must return `true` for a foreign IdentifierId when `crossDomainUserTypes`
+  // is populated — covering the former `structFieldQualifiesForAnyVal` call site
+  // in `DomainInterfaceRenderer` that was local-only and lacked cross-domain
+  // awareness before D01 was fixed.
+  test("canBeAnyValField returns true for foreign IdentifierId via crossDomainUserTypes") {
+    val foreignDomain = DomainId(Seq("idltest"), "foreign_ids")
+    val foreignPath   = TypePath(foreignDomain, Seq.empty)
+    val foreignIdId   = IdentifierId(foreignPath, "ItemID")
+
+    val dtoId = DTOId(tp, "ImplStruct")
+    val field = Field(foreignIdId, "val", emptyMeta)
+    val dto   = NewTypeDef.Dto(dtoId, Struct(List(field), List.empty, Super.empty), emptyMeta)
+
+    val flats = Map[StructureId, FlatStruct](
+      dtoId -> FlatStruct(dtoId, List(FlatField(field, dtoId, 0)), List.empty, List.empty)
+    )
+    val foreignIdDef = NewTypeDef.Identifier(foreignIdId,
+      List(
+        IdField.PrimitiveField(Primitive.TUUID, "id", emptyMeta),
+        IdField.PrimitiveField(Primitive.TUUID, "app", emptyMeta),
+      ), emptyMeta)
+    val ctx = ctxFor(
+      extras               = Map(dtoId -> dto),
+      flats                = flats,
+      crossDomainUserTypes = Map(foreignIdId -> foreignIdDef),
+    )
+    // structCanBeAnyVal is the public entry point that internally calls
+    // canBeAnyValField — asserting it returns true pins the cross-domain
+    // foreign-Identifier branch of the now-unified predicate.
+    assert(DomainAnyvalExtension.structCanBeAnyVal(ctx, dto))
+  }
+
+  // Regression (PR-01-D02): same as above but the foreign type is an
+  // Interface rather than a DTO.
+  test("DTO with single foreign multi-field Interface field gets AnyVal init") {
+    val foreignDomain  = DomainId(Seq("idltest"), "foreign_ids")
+    val foreignPath    = TypePath(foreignDomain, Seq.empty)
+    val foreignIfaceId = InterfaceId(foreignPath, "MultiFieldInterface")
+
+    val fa = Field(Primitive.TString, "a", emptyMeta)
+    val fb = Field(Primitive.TInt32, "b", emptyMeta)
+
+    val dtoId = DTOId(tp, "D")
+    val field = Field(foreignIfaceId, "val", emptyMeta)
+    val dto   = NewTypeDef.Dto(dtoId, Struct(List(field), List.empty, Super.empty), emptyMeta)
+
+    val flats = Map[StructureId, FlatStruct](
+      dtoId -> FlatStruct(dtoId, List(FlatField(field, dtoId, 0)), List.empty, List.empty)
+    )
+    val foreignFlat = FlatStruct(foreignIfaceId, List(FlatField(fa, foreignIfaceId, 0), FlatField(fb, foreignIfaceId, 0)), List.empty, List.empty)
+    val ctx = ctxFor(
+      extras                     = Map(dtoId -> dto),
+      flats                      = flats,
+      crossDomainFlattenedStructs = Map(foreignIfaceId -> foreignFlat),
+    )
+    assert(DomainAnyvalExtension.withAnyvalForComposite(ctx, dto) == List("AnyVal"))
   }
 }

--- a/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/toscala/domain/DomainInterfaceRenderer.scala
+++ b/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/toscala/domain/DomainInterfaceRenderer.scala
@@ -100,7 +100,7 @@ final class DomainInterfaceRenderer(ctx: DomainSTContext) {
     // Name.Anonymous(), Nil).syntax` output.
     val implAnyvalBases: List[String] = {
       val all = implFields.all.map(_.field.field)
-      val canBeAnyVal = all.size == 1 && all.forall(f => structFieldQualifiesForAnyVal(f.typeId))
+      val canBeAnyVal = all.size == 1 && all.forall(f => DomainAnyvalExtension.canBeAnyValField(ctx, f.typeId))
       if (canBeAnyVal) List("AnyVal")
       else List.empty
     }
@@ -154,30 +154,6 @@ final class DomainInterfaceRenderer(ctx: DomainSTContext) {
       companionBaseText = companionTree.mapRender(resolver.resolve),
       toolsText         = toolsTree.mapRender(resolver.resolve),
     )
-  }
-
-  /** AnyVal-field check mirroring `DomainAnyvalExtension.canBeAnyValField`,
-    * inlined because that helper is package-private. */
-  private def structFieldQualifiesForAnyVal(typeId: izumi.idealingua.model.common.TypeId): Boolean = typeId match {
-    case _: izumi.idealingua.model.common.Generic                          => false
-    case _: izumi.idealingua.model.common.Builtin                          => true
-    case _: izumi.idealingua.model.common.TypeId.EnumId                    => true
-    case _: izumi.idealingua.model.common.TypeId.AdtId                     => false
-    case a: izumi.idealingua.model.common.TypeId.AliasId =>
-      ctx.domain.aliases.get(a) match {
-        case Some(target) => structFieldQualifiesForAnyVal(target)
-        case None         => false
-      }
-    case d: izumi.idealingua.model.common.TypeId.DTOId =>
-      ctx.domain.flattenedStructs.get(d).exists(_.fields.size > 1)
-    case i: izumi.idealingua.model.common.TypeId.InterfaceId =>
-      ctx.domain.flattenedStructs.get(i).exists(_.fields.size > 1)
-    case t: izumi.idealingua.model.common.TypeId.IdentifierId =>
-      ctx.domain.userTypes.get(t) match {
-        case Some(izumi.idealingua.typer.ir.TypeDef.Identifier(_, fields, _)) => fields.size > 1
-        case _                                                                 => false
-      }
-    case _ => false
   }
 
   /** Build the trait source string for an interface — exposed so the

--- a/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/toscala/domain/extensions/DomainAnyvalExtension.scala
+++ b/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/toscala/domain/extensions/DomainAnyvalExtension.scala
@@ -1,7 +1,7 @@
 package izumi.idealingua.translator.toscala.domain.extensions
 
-import izumi.idealingua.model.common.TypeId.{AdtId, AliasId, EnumId, IdentifierId, InterfaceId, DTOId}
-import izumi.idealingua.model.common.{Builtin, Generic, TypeId}
+import izumi.idealingua.model.common.TypeId.{AdtId, AliasId, EnumId, IdentifierId}
+import izumi.idealingua.model.common.{Builtin, Generic, StructureId, TypeId}
 import izumi.idealingua.model.problems.IDLException
 import izumi.idealingua.translator.toscala.domain.DomainSTContext
 import izumi.idealingua.translator.toscala.types.ScalaStruct
@@ -116,7 +116,7 @@ object DomainAnyvalExtension {
     * type); the legacy `Struct.all` and the emitted case-class parameter list
     * deduplicate them. AnyVal predicates and forProduct1 codec paths must
     * count the deduped set, not the raw flat. */
-  private def dedupByName(
+  private[domain] def dedupByName(
     fields: List[izumi.idealingua.typer.ir.FlatField]
   ): List[izumi.idealingua.typer.ir.FlatField] =
     fields.groupBy(_.field.name).values.map(_.head).toList
@@ -130,7 +130,7 @@ object DomainAnyvalExtension {
     else List.empty
   }
 
-  private def canBeAnyValField(ctx: DomainSTContext, typeId: TypeId): Boolean =
+  private[domain] def canBeAnyValField(ctx: DomainSTContext, typeId: TypeId): Boolean =
     canBeAnyValField(ctx, typeId, HashSet.empty)
 
   // After F16/Option A1 widening, Service/Buzzer/Streams IDs extend `TypeId` —
@@ -138,7 +138,7 @@ object DomainAnyvalExtension {
   // semantically exhaustive (only the compiler's checker needs a hint).
   @nowarn("msg=match may not be exhaustive")
   @tailrec
-  private def canBeAnyValField(ctx: DomainSTContext, typeId: TypeId, seen: HashSet[TypeId]): Boolean = {
+  private[domain] def canBeAnyValField(ctx: DomainSTContext, typeId: TypeId, seen: HashSet[TypeId]): Boolean = {
     typeId match {
       case _: Generic =>
         false // https://github.com/scala/bug/issues/11170
@@ -155,20 +155,18 @@ object DomainAnyvalExtension {
           case None =>
             throw new IDLException(s"DomainAnyvalExtension: unresolved alias $a")
         }
-      case d: DTOId =>
-        // legacy: "struct.isComposite" — composites cannot be AnyVal-wrapped.
-        // For an interface-impl DTO mirror this is always true.
-        val flat = ctx.domain.flattenedStructs.get(d)
-        flat.exists(_.fields.size > 1)
-      case i: InterfaceId =>
-        val flat = ctx.domain.flattenedStructs.get(i)
-        flat.exists(_.fields.size > 1)
+      case s: StructureId =>
+        // Structural composite (DTO or Interface): `findFlatStruct` checks
+        // local `flattenedStructs` then `crossDomainFlattenedStructs`; no
+        // manual OR needed at the call site.
+        ctx.domain.findFlatStruct(s).exists(_.fields.size > 1)
       case t: IdentifierId =>
-        // legacy: `struct.all.size > 1`. New IR exposes Identifier.fields directly
-        // via `userTypes`; lookup, fall back to `false` when absent.
-        ctx.domain.userTypes.get(t) match {
+        // `findUserType` checks local `userTypes` then `crossDomainUserTypes`;
+        // foreign identifiers referenced from local field positions are reached
+        // without a manual fallback at the call site.
+        ctx.domain.findUserType(t) match {
           case Some(NewTypeDef.Identifier(_, fields, _)) => fields.size > 1
-          case _                                          => false
+          case _ => false
         }
     }
   }

--- a/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/toscala/domain/extensions/DomainCirceTranslatorExtensionBase.scala
+++ b/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/toscala/domain/extensions/DomainCirceTranslatorExtensionBase.scala
@@ -429,7 +429,7 @@ trait DomainCirceTranslatorExtensionBase {
     val dedupedFields: List[izumi.idealingua.typer.ir.FlatField] =
       flatFields.groupBy(_.field.name).values.map(_.head).toList
     val anyvalCase: Boolean = {
-      dedupedFields.size == 1 && dedupedFields.forall(ff => isAnyValField(ctx, ff.field.typeId))
+      dedupedFields.size == 1 && dedupedFields.forall(ff => DomainAnyvalExtension.canBeAnyValField(ctx, ff.field.typeId))
     }
 
     val traitNm = typeName(s"${name}Circe")
@@ -459,32 +459,6 @@ trait DomainCirceTranslatorExtensionBase {
            |}""".stripMargin
       mkCirceTrait(ctx, s"${name}Circe", traitSrc, id)
     }
-  }
-
-  /** Mirrors `DomainAnyvalExtension.canBeAnyValField` — duplicated locally
-    * because that helper is `private` and we need to gate the impl-DTO
-    * AnyVal path here too.
-    */
-  private def isAnyValField(ctx: DomainSTContext, typeId: TypeId): Boolean = typeId match {
-    case _: izumi.idealingua.model.common.Generic       => false
-    case _: izumi.idealingua.model.common.Builtin       => true
-    case _: TypeId.EnumId                                => true
-    case _: TypeId.AdtId                                 => false
-    case a: TypeId.AliasId                               =>
-      ctx.domain.aliases.get(a) match {
-        case Some(target) => isAnyValField(ctx, target)
-        case None         => throw new IDLException(s"unresolved alias $a")
-      }
-    case d: TypeId.DTOId =>
-      ctx.domain.flattenedStructs.get(d).exists(_.fields.size > 1)
-    case i: TypeId.InterfaceId =>
-      ctx.domain.flattenedStructs.get(i).exists(_.fields.size > 1)
-    case t: TypeId.IdentifierId =>
-      ctx.domain.userTypes.get(t) match {
-        case Some(NewTypeDef.Identifier(_, fields, _)) => fields.size > 1
-        case _                                          => false
-      }
-    case _ => false
   }
 
   /** Returns true iff `target` is reachable from `from` by walking only the

--- a/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/totypescript/domain/DomainTSStruct.scala
+++ b/idealingua-v1/idealingua-v1-transpilers/src/main/scala/izumi/idealingua/translator/totypescript/domain/DomainTSStruct.scala
@@ -172,8 +172,7 @@ object DomainTSStruct {
     * (it only reads `Struct.all`).
     */
   def structureOf(domain: Domain, i: InterfaceId): izumi.idealingua.model.typespace.structures.Struct = {
-    val flat = domain.flattenedStructs.get(i)
-      .orElse(domain.crossDomainFlattenedStructs.get(i))
+    val flat = domain.findFlatStruct(i)
       .getOrElse(FlatStruct(i, List.empty, List.empty, List.empty))
     val supers = domain.userTypes.get(i) match {
       case Some(iface: NewTypeDef.Interface) => iface.struct.superclasses


### PR DESCRIPTION
Since 1.5.0 assigning single-field `data` structs to AnyVal would fail if the singular field is defined in another domain.

<hr/>

Single-scalar Scala DTOs whose only field is a cross-domain Identifier (or foreign DTO/Interface) stopped emitting `extends AnyVal` after the Baboon-inspired typer rewrite. The legacy code path used `typespace.structure.structure(t)` for typespace-wide field-count lookups; the new IR's predicates only consulted local `userTypes`/`flattenedStructs`, so any foreign identifier or struct reference in a field position returned `false`.